### PR TITLE
fix: non utf-8 character support

### DIFF
--- a/src/ADBSync/FileSystems/Android.py
+++ b/src/ADBSync/FileSystems/Android.py
@@ -90,7 +90,7 @@ class AndroidFileSystem(FileSystem):
 
         lines_to_yield: List[str] = []
         while adb_line := self.proc_adb_shell.stdout.readline():
-            adb_line = adb_line.decode().rstrip("\r\n")
+            adb_line = adb_line.decode('ISO-8859-1').rstrip("\r\n")
             if adb_line == self.ADBSYNC_END_OF_COMMAND:
                 break
             else:


### PR DESCRIPTION
This was a really quick fix to me getting an error about non UTF-8 strings from an ADB response.

I'm pretty sure this also fixes: #22 