### PR TITLE
Fix issue when file names contain invalid characters

### DIFF
--- a/src/BetterADBSync/FileSystems/Android.py
+++ b/src/BetterADBSync/FileSystems/Android.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Iterator, List, NoReturn, Tuple
+import posixpath
 import logging
 import os
 import re
@@ -94,7 +95,7 @@ class AndroidFileSystem(FileSystem):
 
     def line_not_captured(self, line: str) -> NoReturn:
         logging.critical("ADB line not captured")
-        logging_fatal(line)
+        logging_fatal(line, force_exit = True)
 
     def test_connection(self):
         for line in self.adb_shell([":"]):
@@ -186,14 +187,14 @@ class AndroidFileSystem(FileSystem):
             self.line_not_captured(line)
 
     def join(self, base: str, leaf: str) -> str:
-        return os.path.join(base, leaf).replace("\\", "/") # for Windows
+        return posixpath.join(base, leaf)
 
     def split(self, path: str) -> Tuple[str, str]:
-        head, tail = os.path.split(path)
-        return head.replace("\\", "/"), tail # for Windows
+        head, tail = posixpath.split(path)
+        return head, tail
 
     def normpath(self, path: str) -> str:
-        return os.path.normpath(path).replace("\\", "/")
+        return posixpath.normpath(path)
 
     def push_file_here(self, source: str, destination: str, show_progress: bool = False) -> None:
         if show_progress:
@@ -208,3 +209,6 @@ class AndroidFileSystem(FileSystem):
 
     def convert_invalid_file_name(self, path_destination: str) -> str:
         return path_destination  # no implement on other system
+
+    def validate_args_path(self, path: str) -> str:
+        return path              # no implement on other system

--- a/src/BetterADBSync/FileSystems/Android.py
+++ b/src/BetterADBSync/FileSystems/Android.py
@@ -205,3 +205,6 @@ class AndroidFileSystem(FileSystem):
             }
         if subprocess.call(self.adb_arguments + ["push", source, destination], **kwargs_call):
             logging_fatal("Non-zero exit code from adb push")
+
+    def convert_invalid_file_name(self, path_destination: str) -> str:
+        return path_destination  # no implement on other system

--- a/src/BetterADBSync/FileSystems/Base.py
+++ b/src/BetterADBSync/FileSystems/Base.py
@@ -9,6 +9,7 @@ from ..SAOLogging import perror
 class FileSystem():
     def __init__(self, adb_arguments: List[str]) -> None:
         self.adb_arguments = adb_arguments
+        self.has_invalid_name_potential = False
 
     def _get_files_tree(self, tree_path: str, tree_path_stat: os.stat_result, follow_links: bool = False):
         # the reason to have two functions instead of one purely recursive one is to use self.lstat_in_dir ie ls
@@ -30,6 +31,7 @@ class FileSystem():
             for filename, stat_object_child, in self.lstat_in_dir(tree_path):
                 if filename in [".", ".."]:
                     continue
+                filename = self.convert_invalid_file_name(filename)
                 tree[filename] = self._get_files_tree(
                     self.join(tree_path, filename),
                     stat_object_child,
@@ -138,3 +140,6 @@ class FileSystem():
 
     def push_file_here(self, source: str, destination: str, show_progress: bool = False) -> None:
         raise NotImplementedError
+
+    def convert_invalid_file_name(self, path_destination: str) -> str:
+        raise NotImplementedError  # Problem only persist on Windows. No implement for other system

--- a/src/BetterADBSync/SAOLogging.py
+++ b/src/BetterADBSync/SAOLogging.py
@@ -59,11 +59,13 @@ def setup_root_logger(
     console_handler.setFormatter(formatter_class(fmt = messagefmt_to_use, datefmt = datefmt))
     root_logger.addHandler(console_handler)
 
-def logging_fatal(message, log_stack_info: bool = True, exit_code: int = 1):
+def logging_fatal(message, log_stack_info: bool = True, exit_code: int = 1, force_exit: bool = False):
+    # TODO collect all fatal errors, and show all of it when program terminated. Useful for tracking files that has problems.
     logging.critical(message)
     logging.debug("Stack Trace", stack_info = log_stack_info)
-    logging.critical("Exiting")
-    raise SystemExit(exit_code)
+    if force_exit:
+        logging.critical("Exiting")
+        raise SystemExit(exit_code)
 
 def log_tree(title, tree, finals = None, log_leaves_types = True, logging_level = logging.INFO):
     """Log tree nicely if it is a dictionary.
@@ -94,6 +96,6 @@ def perror(s: Union[str, Any], e: Exception, logging_level: int = logging.ERROR)
     strerror = e.strerror if (isinstance(e, OSError) and e.strerror is not None) else e.__class__.__name__
     msg = f"{s}{': ' if s else ''}{strerror}"
     if logging_level == FATAL:
-        logging_fatal(msg)
+        logging_fatal(msg, force_exit = True)
     else:
         logging.log(logging_level, msg)

--- a/src/BetterADBSync/__init__.py
+++ b/src/BetterADBSync/__init__.py
@@ -328,6 +328,7 @@ class FileSyncer():
         return path_source, path_destination
 
 def main():
+    # TODO implement no-override file flag
     args = get_cli_args(__doc__, __version__)
 
     setup_root_logger(
@@ -364,6 +365,7 @@ def main():
         fs_source = fs_android
         path_destination = args.direction_pull_local
         fs_destination = fs_local
+        fs_local.setup_invalid_name_check()
 
     path_source, path_destination = FileSyncer.paths_to_fixed_destination_paths(path_source, fs_source, path_destination, fs_destination)
 

--- a/src/BetterADBSync/argparsing.py
+++ b/src/BetterADBSync/argparsing.py
@@ -84,7 +84,8 @@ def get_cli_args(docstring: str, version: str) -> Args:
     )
     parser.add_argument("--del",
         help = "Delete files at the destination that are not in the source",
-        action = "store_true",
+        action = argparse.BooleanOptionalAction,
+        default = True,
         dest = "delete"
     )
     parser.add_argument("--delete-excluded",


### PR DESCRIPTION
This problem mostly occur when pulling file from Android to Windows.

I have to implement it in various spots.
1. check if source and destination from user argument is valid.
2. change module from os.path to posixpath referring from [here](https://docs.python.org/3/library/os.path.html), to prevent converting file name from '\\' to '/' on Android side.
3. convert file name in Local side to a valid one.

I also add --no-del option, which will prevent from removing files. I find it useful if I want to transferring to just one side. I implement it in various locations too.
1. change action variable to argparse.BooleanOptionalAction. Reference [here](https://docs.python.org/3/library/argparse.html#action).
2. Make sure that files won't get overridden if --no-del is set.
3. Set condition to not perform delete operation.

Lastly, I also tweak logging_fatal() a bit since it prevents program from running further when there are any fatal error occurs. In my opinion, it feels really bad when program stops while it could still proceed. Like when there are some bad file names. It will halt the works although you could just skip those bad ones.

I have put TODO and FIXME all over the places, you could remove it if you want.